### PR TITLE
Remove jamielennox.oslab.test from template

### DIFF
--- a/roles/packstack/templates/metadata-config.py.j2
+++ b/roles/packstack/templates/metadata-config.py.j2
@@ -4,7 +4,7 @@ from saml2 import BINDING_PAOS
 from saml2.saml import NAME_FORMAT_BASIC
 from saml2.saml import NAMEID_FORMAT_UNSPECIFIED1
 
-BASE = 'https://openstack.jamielennox.oslab.test:5000'
+BASE = 'https://openstack.{{ ipa_domain }}:5000'
 PATH = '/v3/OS-FEDERATION/identity_providers/ipsilon/protocols/saml2/auth'
 URL = BASE + PATH
 


### PR DESCRIPTION
This was just a stupid mistake, this value should come from the ipa
domain and not be hard coded to my instance names.
